### PR TITLE
Rename getChanContents' to getChan'Contents for consistency

### DIFF
--- a/strict-mutable-base/CHANGELOG.md
+++ b/strict-mutable-base/CHANGELOG.md
@@ -1,2 +1,5 @@
+# strict-mutable-base-1.1.0.0 (????-??-??)
+* Rename `getChanContents'` to `getChan'Contents` for consistency.
+
 # strict-mutable-base-1.0.0.0 (2024-09-02)
 * Initial release.

--- a/strict-mutable-base/src/Control/Concurrent/Chan/Strict.hs
+++ b/strict-mutable-base/src/Control/Concurrent/Chan/Strict.hs
@@ -7,7 +7,7 @@ module Control.Concurrent.Chan.Strict
   , writeChan'
   , readChan'
   , dupChan'
-  , getChanContents'
+  , getChan'Contents
   , writeList2Chan'
   ) where
 
@@ -37,8 +37,8 @@ dupChan' :: Chan' a -> IO (Chan' a)
 dupChan' (Chan' chan) = Chan' <$> Base.dupChan chan
 
 -- | 'Base.getChanContents' for 'Chan''.
-getChanContents' :: Chan' a -> IO [a]
-getChanContents' (Chan' chan) = Base.getChanContents chan
+getChan'Contents :: Chan' a -> IO [a]
+getChan'Contents (Chan' chan) = Base.getChanContents chan
 
 -- | 'Base.writeList2Chan' for 'Chan''.
 --

--- a/strict-mutable-base/strict-mutable-base.cabal
+++ b/strict-mutable-base/strict-mutable-base.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               strict-mutable-base
-version:            1.0.0.0
+version:            1.1.0.0
 homepage:           https://github.com/arybczak/strict-mutable
 license:            BSD-3-Clause
 license-file:       LICENSE


### PR DESCRIPTION
An omission, let's fix it now and deprecate 1.0.0.0.