### PR TITLE
Drop ticks in names of all operations and types

### DIFF
--- a/strict-mutable-base/CHANGELOG.md
+++ b/strict-mutable-base/CHANGELOG.md
@@ -1,3 +1,8 @@
+# strict-mutable-base-2.0.0.0 (2026-??-??)
+* Drop ticks in names of all operations and types to make the modules
+  forward-compatible with versions to-be-included in `base`
+  (https://github.com/haskell/core-libraries-committee/issues/341).
+
 # strict-mutable-base-1.1.0.0 (2024-09-04)
 * Rename `getChanContents'` to `getChan'Contents` for consistency.
 

--- a/strict-mutable-base/README.md
+++ b/strict-mutable-base/README.md
@@ -11,3 +11,5 @@ Strict (WHNF) variants of
 [IORef](https://hackage.haskell.org/package/base/docs/Data-IORef.html) and
 [MVar](https://hackage.haskell.org/package/base/docs/Control-Concurrent-MVar.html)
 for proactive prevention of space leaks.
+
+Modules in this package are designed to be imported qualified (usually as `S` or `Strict`, depending on your taste for verbosity).

--- a/strict-mutable-base/src/Control/Concurrent/Chan/Strict.hs
+++ b/strict-mutable-base/src/Control/Concurrent/Chan/Strict.hs
@@ -1,47 +1,47 @@
 -- | For full documentation please refer to "Control.Concurrent.Chan".
 module Control.Concurrent.Chan.Strict
-  ( Chan'
+  ( Chan
 
     -- * Operations
-  , newChan'
-  , writeChan'
-  , readChan'
-  , dupChan'
-  , getChan'Contents
-  , writeList2Chan'
+  , newChan
+  , writeChan
+  , readChan
+  , dupChan
+  , getChanContents
+  , writeList2Chan
   ) where
 
 import Control.Exception (evaluate)
 import qualified Control.Concurrent.Chan as Base
 
 -- | A strict (WHNF) variant of 'Base.Chan'.
-newtype Chan' a = Chan' (Base.Chan a)
+newtype Chan a = Chan (Base.Chan a)
   deriving Eq
 
--- | 'Base.newChan' for 'Chan''.
-newChan' :: IO (Chan' a)
-newChan' = Chan' <$> Base.newChan
+-- | 'Base.newChan' for 'Chan'.
+newChan :: IO (Chan a)
+newChan = Chan <$> Base.newChan
 
--- | 'Base.writeChan' for 'Chan''.
+-- | 'Base.writeChan' for 'Chan'.
 --
 -- Evaluates the value to WHNF.
-writeChan' :: Chan' a -> a -> IO ()
-writeChan' (Chan' chan) a = Base.writeChan chan =<< evaluate a
+writeChan :: Chan a -> a -> IO ()
+writeChan (Chan chan) a = Base.writeChan chan =<< evaluate a
 
--- | 'Base.readChan' for 'Chan''.
-readChan' :: Chan' a -> IO a
-readChan' (Chan' chan) = Base.readChan chan
+-- | 'Base.readChan' for 'Chan'.
+readChan :: Chan a -> IO a
+readChan (Chan chan) = Base.readChan chan
 
--- | 'Base.dupChan' for 'Chan''.
-dupChan' :: Chan' a -> IO (Chan' a)
-dupChan' (Chan' chan) = Chan' <$> Base.dupChan chan
+-- | 'Base.dupChan' for 'Chan'.
+dupChan :: Chan a -> IO (Chan a)
+dupChan (Chan chan) = Chan <$> Base.dupChan chan
 
--- | 'Base.getChanContents' for 'Chan''.
-getChan'Contents :: Chan' a -> IO [a]
-getChan'Contents (Chan' chan) = Base.getChanContents chan
+-- | 'Base.getChanContents' for 'Chan'.
+getChanContents :: Chan a -> IO [a]
+getChanContents (Chan chan) = Base.getChanContents chan
 
--- | 'Base.writeList2Chan' for 'Chan''.
+-- | 'Base.writeList2Chan' for 'Chan'.
 --
 -- Evaluates the values to WHNF.
-writeList2Chan' :: Chan' a -> [a] -> IO ()
-writeList2Chan' = mapM_ . writeChan'
+writeList2Chan :: Chan a -> [a] -> IO ()
+writeList2Chan = mapM_ . writeChan

--- a/strict-mutable-base/src/Control/Concurrent/MVar/Strict.hs
+++ b/strict-mutable-base/src/Control/Concurrent/MVar/Strict.hs
@@ -1,135 +1,135 @@
 -- | For full documentation please refer to "Control.Concurrent.MVar".
 module Control.Concurrent.MVar.Strict
-  ( MVar'
+  ( MVar
 
     -- * Operations
-  , newEmptyMVar'
-  , newMVar'
-  , takeMVar'
-  , putMVar'
-  , readMVar'
-  , swapMVar'
-  , tryTakeMVar'
-  , tryPutMVar'
-  , tryReadMVar'
-  , isEmptyMVar'
-  , withMVar'
-  , withMVar'Masked
-  , modifyMVar'_
-  , modifyMVar'
-  , modifyMVar'Masked_
-  , modifyMVar'Masked
-  , mkWeakMVar'
+  , newEmptyMVar
+  , newMVar
+  , takeMVar
+  , putMVar
+  , readMVar
+  , swapMVar
+  , tryTakeMVar
+  , tryPutMVar
+  , tryReadMVar
+  , isEmptyMVar
+  , withMVar
+  , withMVarMasked
+  , modifyMVar_
+  , modifyMVar
+  , modifyMVarMasked_
+  , modifyMVarMasked
+  , mkWeakMVar
   ) where
 
 import Control.DeepSeq
 import Control.Exception (evaluate)
 import GHC.Exts (mkWeak#)
 import GHC.IO (IO(..))
-import GHC.MVar (MVar(..))
 import GHC.Weak (Weak(..))
 import qualified Control.Concurrent.MVar as Base
+import qualified GHC.MVar as GHC
 
--- | Strict (WHNF) version of 'MVar'.
-newtype MVar' a = MVar' (MVar a)
+-- | Strict (WHNF) version of 'Base.MVar'.
+newtype MVar a = MVar (GHC.MVar a)
   deriving (Eq, NFData, NFData1)
 
--- | 'Base.newEmptyMVar' for an 'MVar''.
-newEmptyMVar' :: IO (MVar' a)
-newEmptyMVar' = MVar' <$> Base.newEmptyMVar
+-- | 'Base.newEmptyMVar' for an 'MVar'.
+newEmptyMVar :: IO (MVar a)
+newEmptyMVar = MVar <$> Base.newEmptyMVar
 
--- | 'Base.newMVar' for an 'MVar''.
+-- | 'Base.newMVar' for an 'MVar'.
 --
 -- Evaluates the initial value to WHNF.
-newMVar' :: a -> IO (MVar' a)
-newMVar' a = fmap MVar' . Base.newMVar =<< evaluate a
+newMVar :: a -> IO (MVar a)
+newMVar a = fmap MVar . Base.newMVar =<< evaluate a
 
--- | 'Base.takeMVar' for an 'MVar''.
-takeMVar' :: MVar' a -> IO a
-takeMVar' (MVar' var) = Base.takeMVar var
+-- | 'Base.takeMVar' for an 'MVar'.
+takeMVar :: MVar a -> IO a
+takeMVar (MVar var) = Base.takeMVar var
 
--- | 'Base.putMVar' for an 'MVar''.
+-- | 'Base.putMVar' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-putMVar' :: MVar' a -> a -> IO ()
-putMVar' (MVar' var) a = Base.putMVar var =<< evaluate a
+putMVar :: MVar a -> a -> IO ()
+putMVar (MVar var) a = Base.putMVar var =<< evaluate a
 
--- | 'Base.readMVar' for an 'MVar''.
-readMVar' :: MVar' a -> IO a
-readMVar' (MVar' var) = Base.readMVar var
+-- | 'Base.readMVar' for an 'MVar'.
+readMVar :: MVar a -> IO a
+readMVar (MVar var) = Base.readMVar var
 
--- | 'Base.swapMVar' for an 'MVar''.
+-- | 'Base.swapMVar' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-swapMVar' :: MVar' a -> a -> IO a
-swapMVar' (MVar' var) a = Base.swapMVar var =<< evaluate a
+swapMVar :: MVar a -> a -> IO a
+swapMVar (MVar var) a = Base.swapMVar var =<< evaluate a
 
--- | 'Base.tryTakeMVar' for an 'MVar''.
-tryTakeMVar' :: MVar' a -> IO (Maybe a)
-tryTakeMVar' (MVar' var) = Base.tryTakeMVar var
+-- | 'Base.tryTakeMVar' for an 'MVar'.
+tryTakeMVar :: MVar a -> IO (Maybe a)
+tryTakeMVar (MVar var) = Base.tryTakeMVar var
 
--- | 'Base.tryPutMVar' for an 'MVar''.
+-- | 'Base.tryPutMVar' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-tryPutMVar' :: MVar' a -> a -> IO Bool
-tryPutMVar' (MVar' var) a = Base.tryPutMVar var =<< evaluate a
+tryPutMVar :: MVar a -> a -> IO Bool
+tryPutMVar (MVar var) a = Base.tryPutMVar var =<< evaluate a
 
--- | 'Base.tryReadMVar' for an 'MVar''.
-tryReadMVar' :: MVar' a -> IO (Maybe a)
-tryReadMVar' (MVar' var) = Base.tryReadMVar var
+-- | 'Base.tryReadMVar' for an 'MVar'.
+tryReadMVar :: MVar a -> IO (Maybe a)
+tryReadMVar (MVar var) = Base.tryReadMVar var
 
--- | 'Base.isEmptyMVar' for an 'MVar''.
-isEmptyMVar' :: MVar' a -> IO Bool
-isEmptyMVar' (MVar' var) = Base.isEmptyMVar var
+-- | 'Base.isEmptyMVar' for an 'MVar'.
+isEmptyMVar :: MVar a -> IO Bool
+isEmptyMVar (MVar var) = Base.isEmptyMVar var
 
--- | 'Base.withMVar' for an 'MVar''.
-withMVar' :: MVar' a -> (a -> IO b) -> IO b
-withMVar' (MVar' var) action = Base.withMVar var action
-{-# INLINE withMVar' #-}
+-- | 'Base.withMVar' for an 'MVar'.
+withMVar :: MVar a -> (a -> IO b) -> IO b
+withMVar (MVar var) action = Base.withMVar var action
+{-# INLINE withMVar #-}
 
--- | 'Base.withMVarMasked' for an 'MVar''.
-withMVar'Masked :: MVar' a -> (a -> IO b) -> IO b
-withMVar'Masked (MVar' var) action = Base.withMVarMasked var action
-{-# INLINE withMVar'Masked #-}
+-- | 'Base.withMVarMasked' for an 'MVar'.
+withMVarMasked :: MVar a -> (a -> IO b) -> IO b
+withMVarMasked (MVar var) action = Base.withMVarMasked var action
+{-# INLINE withMVarMasked #-}
 
--- | 'Base.modifyMVar_' for an 'MVar''.
+-- | 'Base.modifyMVar_' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-modifyMVar'_ :: MVar' a -> (a -> IO a) -> IO ()
-modifyMVar'_ (MVar' var) action = Base.modifyMVar_ var $ \a0 -> do
+modifyMVar_ :: MVar a -> (a -> IO a) -> IO ()
+modifyMVar_ (MVar var) action = Base.modifyMVar_ var $ \a0 -> do
   a <- action a0
   evaluate a
-{-# INLINE modifyMVar'_ #-}
+{-# INLINE modifyMVar_ #-}
 
--- | 'Base.modifyMVar' for an 'MVar''.
+-- | 'Base.modifyMVar' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-modifyMVar' :: MVar' a -> (a -> IO (a, b)) -> IO b
-modifyMVar' (MVar' var) action = Base.modifyMVar var $ \a0 -> do
+modifyMVar :: MVar a -> (a -> IO (a, b)) -> IO b
+modifyMVar (MVar var) action = Base.modifyMVar var $ \a0 -> do
   (a, b) <- action a0
   (, b) <$> evaluate a
-{-# INLINE modifyMVar' #-}
+{-# INLINE modifyMVar #-}
 
--- | 'Base.modifyMVarMasked_' for an 'MVar''.
+-- | 'Base.modifyMVarMasked_' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-modifyMVar'Masked_ :: MVar' a -> (a -> IO a) -> IO ()
-modifyMVar'Masked_ (MVar' var) action = Base.modifyMVarMasked_ var $ \a0 -> do
+modifyMVarMasked_ :: MVar a -> (a -> IO a) -> IO ()
+modifyMVarMasked_ (MVar var) action = Base.modifyMVarMasked_ var $ \a0 -> do
   a <- action a0
   evaluate a
-{-# INLINE modifyMVar'Masked_ #-}
+{-# INLINE modifyMVarMasked_ #-}
 
--- | 'Base.modifyMVarMasked' for an 'MVar''.
+-- | 'Base.modifyMVarMasked' for an 'MVar'.
 --
 -- Evaluates the new value to WHNF.
-modifyMVar'Masked :: MVar' a -> (a -> IO (a, b)) -> IO b
-modifyMVar'Masked (MVar' var) action = Base.modifyMVarMasked var $ \a0 -> do
+modifyMVarMasked :: MVar a -> (a -> IO (a, b)) -> IO b
+modifyMVarMasked (MVar var) action = Base.modifyMVarMasked var $ \a0 -> do
   (a, b) <- action a0
   (, b) <$> evaluate a
-{-# INLINE modifyMVar'Masked #-}
+{-# INLINE modifyMVarMasked #-}
 
--- | 'Base.mkWeakMVar' for an 'MVar''.
-mkWeakMVar' :: MVar' a -> IO () -> IO (Weak (MVar' a))
-mkWeakMVar' var@(MVar' (MVar var#)) (IO finalizer) = IO $ \s0 ->
+-- | 'Base.mkWeakMVar' for an 'MVar'.
+mkWeakMVar :: MVar a -> IO () -> IO (Weak (MVar a))
+mkWeakMVar var@(MVar (GHC.MVar var#)) (IO finalizer) = IO $ \s0 ->
   case mkWeak# var# var finalizer s0 of
     (# s1, w #) -> (# s1, Weak w #)

--- a/strict-mutable-base/src/Data/IORef/Strict.hs
+++ b/strict-mutable-base/src/Data/IORef/Strict.hs
@@ -1,64 +1,64 @@
 -- | For full documentation please refer to "Data.IORef".
 module Data.IORef.Strict
-  ( IORef'
+  ( IORef
 
     -- * Operations
-  , newIORef'
-  , readIORef'
-  , writeIORef'
-  , modifyIORef'
-  , atomicModifyIORef'
-  , atomicWriteIORef'
-  , mkWeakIORef'
+  , newIORef
+  , readIORef
+  , writeIORef
+  , modifyIORef
+  , atomicModifyIORef
+  , atomicWriteIORef
+  , mkWeakIORef
   ) where
 
 import Control.DeepSeq
 import Control.Exception (evaluate)
 import GHC.Exts (mkWeak#)
 import GHC.IO (IO(..))
-import GHC.IORef (IORef(..))
 import GHC.STRef (STRef(..))
 import GHC.Weak (Weak(..))
 import qualified Data.IORef as Base
+import qualified GHC.IORef as GHC
 
--- | A strict (WHNF) variant of 'IORef'.
-newtype IORef' a = IORef' (Base.IORef a)
+-- | A strict (WHNF) variant of 'Base.IORef'.
+newtype IORef a = IORef (Base.IORef a)
   deriving (Eq, NFData, NFData1)
 
--- | 'Base.newIORef' for 'IORef''.
+-- | 'Base.newIORef' for 'IORef'.
 --
 -- Evaluates the initial value to WHNF.
-newIORef' :: a -> IO (IORef' a)
-newIORef' a = fmap IORef' . Base.newIORef =<< evaluate a
+newIORef :: a -> IO (IORef a)
+newIORef a = fmap IORef . Base.newIORef =<< evaluate a
 
--- | 'Base.readIORef' for 'IORef''.
-readIORef' :: IORef' a -> IO a
-readIORef' (IORef' var) = Base.readIORef var
+-- | 'Base.readIORef' for 'IORef'.
+readIORef :: IORef a -> IO a
+readIORef (IORef var) = Base.readIORef var
 
--- | 'Base.writeIORef' for 'IORef''.
+-- | 'Base.writeIORef' for 'IORef'.
 --
 -- Evaluates the new value to WHNF.
-writeIORef' :: IORef' a -> a -> IO ()
-writeIORef' (IORef' var) a = Base.writeIORef var =<< evaluate a
+writeIORef :: IORef a -> a -> IO ()
+writeIORef (IORef var) a = Base.writeIORef var =<< evaluate a
 
--- | 'Base.modifyIORef' for 'IORef''.
-modifyIORef' :: IORef' a -> (a -> a) -> IO ()
-modifyIORef' (IORef' var) f = Base.modifyIORef' var f
+-- | 'Base.modifyIORef' for 'IORef'.
+modifyIORef :: IORef a -> (a -> a) -> IO ()
+modifyIORef (IORef var) f = Base.modifyIORef' var f
 
--- | 'Base.atomicModifyIORef' for 'IORef''.
+-- | 'Base.atomicModifyIORef' for 'IORef'.
 --
 -- Evaluates the new value to WHNF.
-atomicModifyIORef' :: IORef' a -> (a -> (a, b)) -> IO b
-atomicModifyIORef' (IORef' var) f = Base.atomicModifyIORef' var f
+atomicModifyIORef :: IORef a -> (a -> (a, b)) -> IO b
+atomicModifyIORef (IORef var) f = Base.atomicModifyIORef' var f
 
--- | 'Base.atomicWriteIORef' for 'IORef''.
+-- | 'Base.atomicWriteIORef' for 'IORef'.
 --
 -- Evaluates the new value to WHNF.
-atomicWriteIORef' :: IORef' a -> a -> IO ()
-atomicWriteIORef' (IORef' var) a = Base.atomicWriteIORef var =<< evaluate a
+atomicWriteIORef :: IORef a -> a -> IO ()
+atomicWriteIORef (IORef var) a = Base.atomicWriteIORef var =<< evaluate a
 
--- | 'Base.mkWeakIORef' for 'IORef''.
-mkWeakIORef' :: IORef' a -> IO () -> IO (Weak (IORef' a))
-mkWeakIORef' var@(IORef' (IORef (STRef var#))) (IO finalizer) = IO $ \s0 ->
+-- | 'Base.mkWeakIORef' for 'IORef'.
+mkWeakIORef :: IORef a -> IO () -> IO (Weak (IORef a))
+mkWeakIORef var@(IORef (GHC.IORef (STRef var#))) (IO finalizer) = IO $ \s0 ->
   case mkWeak# var# var finalizer s0 of
     (# s1, w #) -> (# s1, Weak w #)

--- a/strict-mutable-base/strict-mutable-base.cabal
+++ b/strict-mutable-base/strict-mutable-base.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 build-type:         Simple
 name:               strict-mutable-base
-version:            1.1.0.0
+version:            2.0.0.0
 homepage:           https://github.com/arybczak/strict-mutable
 license:            BSD-3-Clause
 license-file:       LICENSE


### PR DESCRIPTION
To make the modules forward-compatible with versions to-be-included in `base`.

See https://github.com/haskell/core-libraries-committee/issues/341 for more information.